### PR TITLE
Fix bug when running thpool with nonzero heap allocations.

### DIFF
--- a/tests/bugtraq.sh
+++ b/tests/bugtraq.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+#
+# This file tests for possible bugs
+#
+
+. funcs.sh
+
+
+# ---------------------------- Tests -----------------------------------
+
+function test_with_nonzero_heap_and_stack {
+    compile src/nonzero_heap_stack.c
+    if ! timeout 1 ./test; then
+        err "Fail running on nonzero heap and stack"
+        exit 1
+    else
+        return
+    fi
+}
+
+
+# Run tests
+test_with_nonzero_heap_and_stack
+
+echo "No errors"

--- a/tests/src/nonzero_heap_stack.c
+++ b/tests/src/nonzero_heap_stack.c
@@ -1,0 +1,56 @@
+/*
+ * Try to run thpool with a non-zero heap and stack
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include "../../thpool.h"
+
+
+void task(){
+	printf("Thread #%u working on task\n", (int)pthread_self());
+}
+
+
+void nonzero_stack(){
+    char buf[40096];
+    memset(buf, 0x80, 40096);
+}
+
+
+void nonzero_heap(){
+
+    int i;
+    void *ptrs[200];
+
+    for (i=0; i<200; i++){
+        ptrs[i] = malloc((i+1) << 4);
+        if (ptrs[i])
+            memset(ptrs[i], 0x80, (i+1) << 4);
+    }
+    for (i=0; i<200; i++){
+        free(ptrs[i]);
+    }
+}
+
+
+int main(){
+
+	nonzero_stack();
+	nonzero_heap();
+
+	puts("Making threadpool with 4 threads");
+	threadpool thpool = thpool_init(4);
+
+	puts("Adding 20 tasks to threadpool");
+	int i;
+	for (i=0; i<20; i++){
+		thpool_add_work(thpool, (void*)task, NULL);
+	};
+
+	puts("Killing threadpool");
+	thpool_destroy(thpool);
+	
+	return 0;
+}

--- a/thpool.c
+++ b/thpool.c
@@ -13,6 +13,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <pthread.h>
 #include <errno.h>
 #include <time.h> 
@@ -394,7 +395,12 @@ static int jobqueue_init(thpool_* thpool_p){
 	if (thpool_p->jobqueue_p == NULL){
 		return -1;
 	}
+    memset(thpool_p->jobqueue_p, 0, sizeof(struct jobqueue));
 	thpool_p->jobqueue_p->has_jobs = (struct bsem*)malloc(sizeof(struct bsem));
+	if (thpool_p->jobqueue_p->has_jobs == NULL){
+		return -1;
+	}
+    memset(thpool_p->jobqueue_p->has_jobs, 0, sizeof(struct bsem));
 	bsem_init(thpool_p->jobqueue_p->has_jobs, 0);
 	jobqueue_clear(thpool_p);
 	return 0;


### PR DESCRIPTION
If previous allocations were freed before thpool_init(), them some heap chunks are reused by malloc(), without being zeroed.

As malloc's in jobqueue_init() was not verified, i encountered both segfault and infinite loops.

This is now fixed, and also created an unit test designed to check possible regressions, by
launching a thpool with nonzero stack and heap values.