### PR TITLE
Add THPOOL_DEBUG define (mandatory for debug msgs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is an updated and heavily refactored version of my original threadpool. The
 The library is not precompiled so you have to compile it with your project. The thread pool
 uses POSIX threads so if you compile with gcc on Linux you have to use the flag `-pthread` like this:
 
-    gcc example.c thpool.c -pthread -o example
+    gcc example.c thpool.c -D THPOOL_DEBUG -pthread -o example
 
 
 Then run the executable like this:

--- a/tests/funcs.sh
+++ b/tests/funcs.sh
@@ -40,5 +40,5 @@ function err { #string #log
 
 
 function compile { #cfilepath
-	gcc $COMPILATION_FLAGS "$1" ../thpool.c -pthread -o test
+	gcc $COMPILATION_FLAGS "$1" ../thpool.c -D THPOOL_DEBUG -pthread -o test
 }

--- a/thpool.c
+++ b/thpool.c
@@ -144,7 +144,9 @@ struct thpool_* thpool_init(int num_threads){
 	int n;
 	for (n=0; n<num_threads; n++){
 		thread_init(thpool_p, &thpool_p->threads[n], n);
-		printf("Created thread %d in pool \n", n);
+#ifdef THPOOL_DEBUG
+		printf("THPOOL_DEBUG: Created thread %d in pool \n", n);
+#endif
 	}
 	
 	/* Wait for threads to initialize */


### PR DESCRIPTION
Hi joan,
Added this because some messages are not designed to be printed
while integrating thpool in an existing project.

For example, the message " Created thread %d in pool ..." is very
useful to debug, and/or learn how thpool works, but we generally don't want it
printed while integrating it on an existing project.