### PR TITLE
fix mutex init bug

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -395,7 +395,7 @@ static int jobqueue_init(thpool_* thpool_p){
 		return -1;
 	}
 	thpool_p->jobqueue_p->has_jobs = (struct bsem*)malloc(sizeof(struct bsem));
-    pthread_mutex_init(&thpool_p->jobqueue_p->rwmutex, NULL);
+	pthread_mutex_init(&thpool_p->jobqueue_p->rwmutex, NULL);
 	bsem_init(thpool_p->jobqueue_p->has_jobs, 0);
 	jobqueue_clear(thpool_p);
 	return 0;

--- a/thpool.c
+++ b/thpool.c
@@ -395,6 +395,7 @@ static int jobqueue_init(thpool_* thpool_p){
 		return -1;
 	}
 	thpool_p->jobqueue_p->has_jobs = (struct bsem*)malloc(sizeof(struct bsem));
+    pthread_mutex_init(&thpool_p->jobqueue_p->rwmutex, NULL);
 	bsem_init(thpool_p->jobqueue_p->has_jobs, 0);
 	jobqueue_clear(thpool_p);
 	return 0;


### PR DESCRIPTION
Without initialization of mutex in jobqueue, two threads can both hold the mutex and leads to double free of job pointer. ( tested on OS X )