### PR TITLE
initilise jobqueue_p->len to 0

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -410,7 +410,7 @@ static int jobqueue_init(thpool_* thpool_p){
 		return -1;
 	}
 	bsem_init(thpool_p->jobqueue_p->has_jobs, 0);
-	
+	thpool_p->jobqueue_p->len = 0;
 	jobqueue_clear(thpool_p);
 	return 0;
 }


### PR DESCRIPTION
Without the initilization, Segment fault happens when jobqueue_clear() is called.