### PR TITLE
Valgrind uninitialised value error

### DIFF
--- a/tests/memleaks.sh
+++ b/tests/memleaks.sh
@@ -10,6 +10,18 @@
 
 # ---------------------------- Tests -----------------------------------
 
+function test_thread_errors {
+	echo "Testing creation and destruction of threads for errors (=$1)"
+	compile src/no_work.c
+	output=$(valgrind --leak-check=full --track-origins=yes ./test "$1" 2>&1 > /dev/null)
+	error_summary=$(echo "$output" | grep "ERROR SUMMARY")
+	errors=$(extract_num "[0-9]* errors" "$error_summary")
+	if (( "$errors" == 0 )); then
+		return
+	fi
+	err "Valgrind returned $errors errors"
+	exit 1
+}
 
 function test_thread_free { #threads
 	echo "Testing creation and destruction of threads(=$1)"
@@ -55,6 +67,7 @@ function test_thread_free_multi { #threads #times
 
 
 # Run tests
+test_thread_errors 1
 test_thread_free 1
 test_thread_free 2
 test_thread_free 4

--- a/thpool.c
+++ b/thpool.c
@@ -336,6 +336,8 @@ static void* thread_do(struct thread* thread_p){
 	
 	/* Register signal handler */
 	struct sigaction act;
+	sigemptyset(&act.sa_mask);
+	act.sa_flags = 0;
 	act.sa_handler = thread_hold;
 	if (sigaction(SIGUSR1, &act, NULL) == -1) {
 		fprintf(stderr, "thread_do(): cannot handle SIGUSR1");


### PR DESCRIPTION
Added a test to check for errors reported by Valgrind and fixed reported errors..

Syscall param rt_sigaction(act->sa_mask) points to uninitialised byte(s)
Syscall param rt_sigaction(act->sa_flags) points to uninitialised byte(s)