### PR TITLE
add thread name, fix warning in the example

### DIFF
--- a/example.c
+++ b/example.c
@@ -12,6 +12,7 @@
  * */
 
 #include <stdio.h>
+#include <pthread.h>
 #include "thpool.h"
 
 

--- a/thpool.c
+++ b/thpool.c
@@ -16,6 +16,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <time.h> 
+#include <sys/prctl.h>
 
 #include "thpool.h"
 
@@ -335,6 +336,10 @@ static void thread_hold () {
 * @return nothing
 */
 static void* thread_do(struct thread* thread_p){
+	/* Set thread name for profiling and debuging */
+	char thread_name[128] = {0};
+	sprintf(thread_name, "thread-pool-%d", thread_p->id);
+	prctl(PR_SET_NAME, thread_name);
 
 	/* Assure all threads have been created before starting serving */
 	thpool_* thpool_p = thread_p->thpool_p;


### PR DESCRIPTION
thread name is good for both profiling and debuging
also htop can turn on the option 'Show custom thread names' in 'Display
options' to see the status of a specific thread worker
the warning in example is ‘pthread_self’ [-Wimplicit-function-declaration]