### PR TITLE
some fixes

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -8,7 +8,9 @@
  * 
  ********************************/
 
+#if defined(__linux__)
 #define _GNU_SOURCE
+#endif
 #include <unistd.h>
 #include <signal.h>
 #include <stdio.h>

--- a/thpool.c
+++ b/thpool.c
@@ -8,7 +8,7 @@
  * 
  ********************************/
 
-
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <signal.h>
 #include <stdio.h>
@@ -197,7 +197,9 @@ void thpool_wait(thpool_* thpool_p){
 
 /* Destroy the threadpool */
 void thpool_destroy(thpool_* thpool_p){
-	
+	/* No need to destory if it's NULL */
+	if (thpool_p == NULL) return ;
+
 	volatile int threads_total = thpool_p->num_threads_alive;
 
 	/* End each thread 's infinite loop */

--- a/thpool.c
+++ b/thpool.c
@@ -8,9 +8,6 @@
  * 
  ********************************/
 
-#if defined(__linux__)
-#define _GNU_SOURCE
-#endif
 #include <unistd.h>
 #include <signal.h>
 #include <stdio.h>
@@ -18,6 +15,9 @@
 #include <pthread.h>
 #include <errno.h>
 #include <time.h> 
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
 #include "thpool.h"
 
 #ifdef THPOOL_DEBUG
@@ -306,7 +306,8 @@ static void* thread_do(struct thread* thread_p){
 	sprintf(thread_name, "thread-pool-%d", thread_p->id);
 
 #if defined(__linux__)
-	pthread_setname_np(thread_p->pthread, thread_name);
+	/* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */
+	prctl(PR_SET_NAME, thread_name);
 #elif defined(__APPLE__) && defined(__MACH__)
 	pthread_setname_np(thread_name);
 #else


### PR DESCRIPTION
`_GNU_SOURCE` is from the Linux Programmer's Manual: http://man7.org/linux/man-pages/man3/pthread_setname_np.3.html
This macro also cause some problems mentioned here:
http://stackoverflow.com/questions/5582211/what-does-define-gnu-source-imply
While `pthread_setname_np` is more generic, it is an nonstandard GNU/Linux extension function and would cause some problems in some situations.
I suggest to use `prctl` instead on Linux and use `pthread_setname_np` on MAC. It's the final version of this pull request.