### PR TITLE
Whole thread workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+CFLAGS+=-ggdb -DTHPOOL_DEBUG
+LDFLAGS+=-lpthread
+example: example.o thpool.o

--- a/example.c
+++ b/example.c
@@ -10,32 +10,30 @@
  * a decision of the OS.
  * 
  * */
+#include "thpool.h"
 
 #include <stdio.h>
 #include <pthread.h>
-#include "thpool.h"
+#include <stdint.h> // intptr_t
 
 
-void task1(){
-	printf("Thread #%u working on task1\n", (int)pthread_self());
-}
-
-
-void task2(){
-	printf("Thread #%u working on task2\n", (int)pthread_self());
+void worker(int job){
+	printf("Thread #%u working on task %d\n", (int)pthread_self(), job);
+	sleep(1);
+	printf("Thread #%u done with task %d\n", (int)pthread_self(), job);
 }
 
 
 int main(){
 	
 	puts("Making threadpool with 4 threads");
-	threadpool thpool = thpool_init(4);
+	threadpool thpool = thpool_init((void*)worker,4);
 
 	puts("Adding 40 tasks to threadpool");
 	int i;
 	for (i=0; i<20; i++){
-		thpool_add_work(thpool, (void*)task1, NULL);
-		thpool_add_work(thpool, (void*)task2, NULL);
+		thpool_add_work(thpool, (void*)((intptr_t)i<<1));
+		thpool_add_work(thpool, (void*)((intptr_t)(i<<1+1)));
 	};
 
 	puts("Killing threadpool");

--- a/example.c
+++ b/example.c
@@ -15,31 +15,37 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <stdint.h> // intptr_t
+#include <unistd.h> // sleep
 
+intptr_t mainthread;
+// I have no idea if these numbers even work on 32 bits haha
+#define THREAD_ID ((mainthread-((intptr_t)pthread_self()))	\
+				   >>										\
+				   ((sizeof(void*)<<1)+7))
 
-void worker(threadpool queue, int who) {
-  printf("Thread #%d starting! (%p)",pthread_self());
+void worker(threadpool queue, void* arg) {
+  printf("Thread %d starting!\n",THREAD_ID);
   void* work; // work MUST be at least the size of a void* or segfault!
   while(thpool_get_work(queue,&work)) {
-	int job = (int) work;
-	printf("Thread #%d working on task %d (%p)\n", who, job, pthread_self());
+	int job = (intptr_t) work;
+	printf("Thread %d working on task %d\n", THREAD_ID, job);
 	sleep(1);
-	printf("Thread #%d done with task %d\n", who, job);
+	printf("Thread %d done with task %d\n", THREAD_ID, job);
   }
-  printf("Thread #%d cleaning up", who);
+  printf("Thread %d cleaning up\n", THREAD_ID);
 }
 
 
 int main(){
-	
+	mainthread = (intptr_t)pthread_self();
 	puts("Making threadpool with 4 threads");
-	threadpool thpool = thpool_init((void*)worker,4);
+	threadpool thpool = thpool_init(4,(void*)worker,NULL);
 
 	puts("Adding 40 tasks to threadpool");
 	int i;
 	for (i=0; i<20; i++){
-		thpool_add_work(thpool, (void*)((intptr_t)i<<1));
-		thpool_add_work(thpool, (void*)((intptr_t)(i<<1+1)));
+		thpool_add_work(thpool, (void*)((intptr_t)(i<<1)));
+		thpool_add_work(thpool, (void*)((intptr_t)(i<<1)+1));
 	};
 
 	thpool_wait(thpool);

--- a/example.c
+++ b/example.c
@@ -17,10 +17,16 @@
 #include <stdint.h> // intptr_t
 
 
-void worker(int job){
-	printf("Thread #%x working on task %d\n", ((uint16_t)pthread_self()) % 0x1000, job);
+void worker(threadpool queue, int who) {
+  printf("Thread #%d starting! (%p)",pthread_self());
+  void* work; // work MUST be at least the size of a void* or segfault!
+  while(thpool_get_work(queue,&work)) {
+	int job = (int) work;
+	printf("Thread #%d working on task %d (%p)\n", who, job, pthread_self());
 	sleep(1);
-	printf("Thread #%x done with task %d\n", ((uint16_t)pthread_self()) % 0xf84, job);
+	printf("Thread #%d done with task %d\n", who, job);
+  }
+  printf("Thread #%d cleaning up", who);
 }
 
 

--- a/example.c
+++ b/example.c
@@ -18,9 +18,9 @@
 
 
 void worker(int job){
-	printf("Thread #%u working on task %d\n", (int)pthread_self(), job);
+	printf("Thread #%x working on task %d\n", ((uint16_t)pthread_self()) % 0x1000, job);
 	sleep(1);
-	printf("Thread #%u done with task %d\n", (int)pthread_self(), job);
+	printf("Thread #%x done with task %d\n", ((uint16_t)pthread_self()) % 0xf84, job);
 }
 
 
@@ -36,6 +36,7 @@ int main(){
 		thpool_add_work(thpool, (void*)((intptr_t)(i<<1+1)));
 	};
 
+	thpool_wait(thpool);
 	puts("Killing threadpool");
 	thpool_destroy(thpool);
 	

--- a/thpool.c
+++ b/thpool.c
@@ -195,7 +195,7 @@ void thpool_wait(thpool_* thpool_p){
 
 /* Destroy the threadpool */
 void thpool_destroy(thpool_* thpool_p){
-	/* No need to destory if it's NULL */
+	/* No need to destroy if it's NULL */
 	if (thpool_p == NULL) return ;
 
 	volatile int threads_total = thpool_p->num_threads_alive;

--- a/thpool.c
+++ b/thpool.c
@@ -22,8 +22,10 @@
 
 #ifdef THPOOL_DEBUG
 #define THPOOL_DEBUG 1
+#define assert(a) if(!a) { fputs("assertion failed " #a,stderr); abort(); }
 #else
 #define THPOOL_DEBUG 0
+#define assert(a)
 #endif
 
 static volatile int threads_keepalive;

--- a/thpool.c
+++ b/thpool.c
@@ -74,7 +74,7 @@ typedef struct thpool_{
 	volatile int num_threads_working;    /* threads currently working */
 	pthread_mutex_t  thcount_lock;       /* used for thread count etc */
 	pthread_cond_t  threads_all_idle;    /* signal to thpool_wait     */
-    void*  (*handler)(void* arg);        /* function pointer          */
+    void*  (*worker)(void* arg);        /* function pointer          */
 	jobqueue*  jobqueue_p;               /* pointer to the job queue  */    
 } thpool_;
 
@@ -328,7 +328,7 @@ static void* thread_do(struct thread* thread_p){
 	pthread_mutex_unlock(&thpool_p->thcount_lock);
 
 	void (*func_buff)(void*) =
-	  thpool_p->handler;
+	  thpool_p->worker;
 
 	while(threads_keepalive){
 

--- a/thpool.h
+++ b/thpool.h
@@ -30,21 +30,23 @@ typedef struct thpool_* threadpool;
  *    thpool = thpool_init(4);               //then we initialize it to 4 threads
  *    ..
  * 
+ * @param  function_p    pointer to function to add as work
  * @param  num_threads   number of threads to be created in the threadpool
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(int num_threads);
+threadpool thpool_init(void (*)(void*), int num_threads);
 
 
 /**
  * @brief Add work to the job queue
  * 
- * Takes an action and its argument and adds it to the threadpool's job queue.
+ * Takes work and adds it to the threadpool's job queue.
  * If you want to add to work a function with more than one arguments then
  * a way to implement this is by passing a pointer to a structure.
  * 
- * NOTICE: You have to cast both the function and argument to not get warnings.
+ * NOTICE: You have to cast argument to not get warnings.
+ * NOTICE: Any pointers added should be considered moved.
  * 
  * @example
  * 
@@ -54,17 +56,18 @@ threadpool thpool_init(int num_threads);
  * 
  *    int main() {
  *       ..
+ *       thpool_init((void*)print_num, 1234);
+ *       ..
  *       int a = 10;
- *       thpool_add_work(thpool, (void*)print_num, (void*)a);
+ *       thpool_add_work(thpool, (void*)a);
  *       ..
  *    }
  * 
  * @param  threadpool    threadpool to which the work will be added
- * @param  function_p    pointer to function to add as work
  * @param  arg_p         pointer to an argument
  * @return 0 on successs, -1 otherwise.
  */
-int thpool_add_work(threadpool, void *(*function_p)(void*), void* arg_p);
+int thpool_add_work(threadpool, void* arg_p);
 
 
 /**

--- a/thpool.h
+++ b/thpool.h
@@ -27,7 +27,7 @@ typedef struct thpool_* threadpool;
  * 
  *    ..
  *    threadpool thpool;                     //First we declare a threadpool
- *    thpool = thpool_init(4);               //then we initialize it to 4 threads
+ *    thpool = thpool_init(worker,4);               //then we initialize it to 4 threads
  *    ..
  * 
  * @param  function_p    pointer to function to add as work
@@ -86,7 +86,7 @@ int thpool_add_work(threadpool, void* arg_p);
  * @example
  * 
  *    ..
- *    threadpool thpool = thpool_init(4);
+ *    threadpool thpool = thpool_init(worker, 4);
  *    ..
  *    // Add a bunch of work
  *    ..
@@ -111,7 +111,7 @@ void thpool_wait(threadpool);
  * 
  * @example
  * 
- *    threadpool thpool = thpool_init(4);
+ *    threadpool thpool = thpool_init(worker, 4);
  *    thpool_pause(thpool);
  *    ..
  *    // Add a bunch of work
@@ -148,8 +148,8 @@ void thpool_resume(threadpool);
  * 
  * @example
  * int main() {
- *    threadpool thpool1 = thpool_init(2);
- *    threadpool thpool2 = thpool_init(2);
+ *    threadpool thpool1 = thpool_init(worker, 2);
+ *    threadpool thpool2 = thpool_init(worker, 2);
  *    ..
  *    thpool_destroy(thpool1);
  *    ..

--- a/thpool.h
+++ b/thpool.h
@@ -31,6 +31,9 @@ typedef void (*thpool_worker)(threadpool,void*);
  * 
  * Initializes a threadpool. This function will not return untill all
  * threads have initialized successfully.
+ *
+ * NOTE: arg parameter is just because I'm absolutely paranoid about C and
+ * closures. It's passed to all workers, and not locked, or thread safe!
  * 
  * @example
  * 

--- a/thpool.h
+++ b/thpool.h
@@ -24,7 +24,7 @@ typedef struct thpool_* threadpool;
  * thpool_quitting() returns 0.
  */
 
-typdef void (*thpool_worker)(threadpool,void*)
+typedef void (*thpool_worker)(threadpool,void*);
 
 /**
  * @brief  Initialize threadpool
@@ -39,13 +39,13 @@ typdef void (*thpool_worker)(threadpool,void*)
  *    thpool = thpool_init(worker,4);               //then we initialize it to 4 threads
  *    ..
  * 
- * @param  function_p    pointer to function to add as work
  * @param  num_threads   number of threads to be created in the threadpool
+ * @param  worker    pointer to function to process work
+ * @param  arg       argument to pass to worker on startup.
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(thpool_worker, int num_threads);
-
+threadpool thpool_init(int num_threads, thpool_worker worker, void* arg);
 
 /**
  * @brief Add work to the job queue
@@ -110,10 +110,10 @@ int thpool_add_work(threadpool, void* arg_p);
  * 
  * @param  threadpool    threadpool to get work from.
  * @param  work          where to put the next job.
- * @return NULL if should exit, otherwise thpool_add_work arg.
+ * @return 0 if should exit, otherwise amount of retries waiting for jobs
  */
  
-void* thpool_get_work(thpool_* thpool_p, void** work);
+short thpool_get_work(threadpool queue, void** work);
 
 /**
  * @brief Wait for all queued jobs to finish


### PR DESCRIPTION
I always wanted a thread pool whose workers pulled from a queue. Just made more mental sense to me, since I always use thread pools to parallelize a large number of identical or very similar tasks. Pull if you like, or don't. This way allows for custom setup and cleanup of each worker, FWIW.