### PR TITLE
Thread name warning should only appear under debug.

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -310,7 +310,7 @@ static void* thread_do(struct thread* thread_p){
 	prctl(PR_SET_NAME, thread_name);
 #elif defined(__APPLE__) && defined(__MACH__)
 	pthread_setname_np(thread_name);
-#else
+#elif THPOOL_DEBUG
 	fprintf(stderr, "thread_do(): pthread_setname_np is not supported on this system");
 #endif
 


### PR DESCRIPTION
It serves no real purpose other than debugging, hurts performance and we don't really need a reminder when we're stuck in Windows!