### PR TITLE
Added job pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,24 @@ Then run the executable like this:
 ## Basic usage
 
 1. Include the header in your source file: `#include "thpool.h"`
-2. Create a thread pool with number of threads you want: `threadpool thpool = thpool_init(4);`
+2. Create a thread pool with number of threads and jobs you want: `threadpool thpool = thpool_init(4, 5);`
 3. Add work to the pool: `thpool_add_work(thpool, (void*)function_p, (void*)arg_p);`
 
 The workers(threads) will start their work automatically as fast as there is new work
 in the pool. If you want to wait for all added work to be finished before continuing
 you can use `thpool_wait(thpool);`. If you want to destroy the pool you can use
 `thpool_destroy(thpool);`.
+
+The number of jobs passed as the second argument to `thpool_init()` will be the initial size
+of a job pool within the threadpool itself. This job pool will work in much the same manner
+as the thread pool itself - it will reuse jobs to avoid unncessary allocations and deallocations.
+Please note that if this number is too small the pool will create more jobs to fulfill the need
+on the fly.
+
+As an example, consider a situation where there will never be more than 5 jobs queued at once.
+If the initial size is less than 5, time will be wasted creating more jobs to queue, and if the 
+intial size is larger than 5, time will be wasted creating more jobs than necessary during `thpool_init()`.
+Here the ideal initial number would be 5 jobs, for maximum efficiency and performance.
 
 
 ## API
@@ -43,7 +54,7 @@ For a deeper look into the documentation check in the [thpool.h](https://github.
 
 | Function example                | Description                                                         |
 |---------------------------------|---------------------------------------------------------------------|
-| ***thpool_init(4)***            | Will return a new threadpool with `4` threads.                        |
+| ***thpool_init(4, 5)***         | Will return a new threadpool with `4` threads and `5` jobs.         |
 | ***thpool_add_work(thpool, (void&#42;)function_p, (void&#42;)arg_p)*** | Will add new work to the pool. Work is simply a function. You can pass a single argument to the function if you wish. If not, `NULL` should be passed. |
 | ***thpool_wait(thpool)***       | Will wait for all jobs (both in queue and currently running) to finish. |
 | ***thpool_destroy(thpool)***    | This will destroy the threadpool. If jobs are currently being executed, then it will wait for them to finish. |

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,0 +1,20 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -Wstrict-prototypes -o3 -pthread
+SOURCES=../thpool.c benchmark.c
+HEADERS=../thpool.h
+SOURCES_OLD=thpool_old.c benchmark_old.c
+HEADERS_OLD=thpool_old.h
+
+.PHONY: clean
+
+all: benchmark benchmark_old
+	python3 run_benchmark.py
+
+benchmark: $(SOURCES) $(HEADERS)
+	$(CC) $(CFLAGS) -o $@ $(SOURCES)
+
+benchmark_old: $(SOURCES_OLD) $(HEADERS_OLD)
+	$(CC) $(CFLAGS) -o $@ $(SOURCES_OLD)
+
+clean:
+	rm -f benchmark benchmark_old benchmark*.csv benchmark*.png

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -1,0 +1,28 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../thpool.h"
+
+void sleep_task(void *boop){
+    (void)boop;
+    sleep(0.1);
+}
+
+int main(int argc, char **argv){
+	char* p;
+	if (argc != 4){
+		puts("This benchmark needs exactly three arguments: thread number, job number and task number.\n");
+		return(1);
+	}
+	size_t num_threads = strtol(argv[1], &p, 10);
+	size_t num_jobs    = strtol(argv[2], &p, 10);
+	size_t num_tasks   = strtol(argv[3], &p, 10);
+
+	threadpool pool = thpool_init(num_threads, num_jobs);
+	size_t n;
+	for (n = 0; n < num_tasks; n++){
+		thpool_add_work(pool, sleep_task, NULL);
+	}
+	thpool_wait(pool);
+    thpool_destroy(pool);
+}

--- a/benchmark/benchmark_old.c
+++ b/benchmark/benchmark_old.c
@@ -1,0 +1,27 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "thpool_old.h"
+
+void sleep_task(void *boop){
+    (void)boop;
+    sleep(0.1);
+}
+
+int main(int argc, char **argv){
+    char* p;
+    if (argc != 3){
+        printf("This benchmark needs exactly two arguments: thread number and task number.\n");
+        return(1);
+    }
+    size_t num_threads = strtol(argv[1], &p, 10);
+    size_t num_tasks   = strtol(argv[2], &p, 10);
+
+    threadpool pool = thpool_init(num_threads);
+    size_t n;
+    for (n = 0; n < num_tasks; n++){
+        thpool_add_work(pool, sleep_task, NULL);
+    }
+    thpool_wait(pool);
+    thpool_destroy(pool);
+}

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+from timeit import timeit
+from subprocess import run
+from itertools import product
+from collections import OrderedDict
+
+thread_nums = (8,)  # most common thread numbers, I imagine
+job_nums = range(0, 100000, 10000)
+task_nums = (10, 100, 1000, 10000, 100000, 1000000)
+
+# this becomes a list of tuples (thread_num, job_num, task_num)
+master_list = product(thread_nums, job_nums, task_nums)
+
+plot_dict = OrderedDict()
+for group in master_list:
+    print("Running with {} threads, {} jobs and {} tasks.".format(*group))
+    time = timeit("run(['./benchmark', '{}', '{}', '{}'])".format(*group), globals=globals(), number=10)
+    plot_list = plot_dict.get(group[2], [[], []])
+    plot_list[0].append(group[1])
+    plot_list[1].append(time)
+    plot_dict[group[2]] = plot_list
+
+try:
+    import matplotlib.pyplot as plt
+    fignum = 1
+    for key, value in plot_dict.items():
+        plt.figure(fignum)
+        plt.title("Task Number: {}".format(key))
+        plt.plot(*value, 'ro')
+        plt.xlabel("job_num")
+        plt.ylabel("time")
+        fignum = fignum + 1
+        plt.savefig("benchmark{}.png".format(key))
+except ImportError:
+    pass
+
+with open('benchmark.csv', 'a') as fname:
+    for key, value in plot_dict.items():
+        for i in range(len(value[0])):
+            fname.write('{}, {}, {}\n'.format(key, value[0][i], value[1][i]))
+
+# this becomes a list of tuples (thread_num, task_num)
+master_list = product(thread_nums, task_nums)
+
+plot_list = [[], []]
+for group in master_list:
+    print("Running old with {} threads and {} tasks.".format(*group))
+    time = timeit("run(['./benchmark_old', '{}', '{}'])".format(*group), globals=globals(), number=10)
+    plot_list[0].append(group[1])
+    plot_list[1].append(time)
+
+try:
+    import matplotlib.pyplot as plt
+    plt.title("Old Benchmark")
+    plt.plot(*plot_list, 'ro')
+    plt.xlabel("task_num")
+    plt.ylabel("time")
+    plt.savefig("benchmark_old.png")
+except ImportError:
+    pass
+
+with open('benchmark_old.csv', 'a') as fname:
+    for i in range(len(plot_list[0])):
+        fname.write('{}, {}\n'.format(plot_list[0][i], plot_list[1][i]))

--- a/benchmark/thpool_old.c
+++ b/benchmark/thpool_old.c
@@ -1,0 +1,551 @@
+/* ********************************
+ * Author:       Johan Hanssen Seferidis
+ * License:      MIT
+ * Description:  Library providing a threading pool where you can add
+ *               work. For usage, check the thpool.h file or README.md
+ *
+ *//** @file thpool.h *//*
+ *
+ ********************************/
+
+#define _POSIX_C_SOURCE 200809L
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <errno.h>
+#include <time.h>
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
+
+#include "thpool_old.h"
+
+#ifdef THPOOL_DEBUG
+#define THPOOL_DEBUG 1
+#else
+#define THPOOL_DEBUG 0
+#endif
+
+#if !defined(DISABLE_PRINT) || defined(THPOOL_DEBUG)
+#define err(str) fprintf(stderr, str)
+#else
+#define err(str)
+#endif
+
+static volatile int threads_keepalive;
+static volatile int threads_on_hold;
+
+
+
+/* ========================== STRUCTURES ============================ */
+
+
+/* Binary semaphore */
+typedef struct bsem {
+    pthread_mutex_t mutex;
+    pthread_cond_t   cond;
+    int v;
+} bsem;
+
+
+/* Job */
+typedef struct job{
+    struct job*  prev;                   /* pointer to previous job   */
+    void   (*function)(void* arg);       /* function pointer          */
+    void*  arg;                          /* function's argument       */
+} job;
+
+
+/* Job queue */
+typedef struct jobqueue{
+    pthread_mutex_t rwmutex;             /* used for queue r/w access */
+    job  *front;                         /* pointer to front of queue */
+    job  *rear;                          /* pointer to rear  of queue */
+    bsem *has_jobs;                      /* flag as binary semaphore  */
+    int   len;                           /* number of jobs in queue   */
+} jobqueue;
+
+
+/* Thread */
+typedef struct thread{
+    int       id;                        /* friendly id               */
+    pthread_t pthread;                   /* pointer to actual thread  */
+    struct thpool_* thpool_p;            /* access to thpool          */
+} thread;
+
+
+/* Threadpool */
+typedef struct thpool_{
+    thread**   threads;                  /* pointer to threads        */
+    volatile int num_threads_alive;      /* threads currently alive   */
+    volatile int num_threads_working;    /* threads currently working */
+    pthread_mutex_t  thcount_lock;       /* used for thread count etc */
+    pthread_cond_t  threads_all_idle;    /* signal to thpool_wait     */
+    jobqueue  jobqueue;                  /* job queue                 */
+} thpool_;
+
+
+
+
+
+/* ========================== PROTOTYPES ============================ */
+
+
+static int  thread_init(thpool_* thpool_p, struct thread** thread_p, int id);
+static void* thread_do(struct thread* thread_p);
+static void  thread_hold(int sig_id);
+static void  thread_destroy(struct thread* thread_p);
+
+static int   jobqueue_init(jobqueue* jobqueue_p);
+static void  jobqueue_clear(jobqueue* jobqueue_p);
+static void  jobqueue_push(jobqueue* jobqueue_p, struct job* newjob_p);
+static struct job* jobqueue_pull(jobqueue* jobqueue_p);
+static void  jobqueue_destroy(jobqueue* jobqueue_p);
+
+static void  bsem_init(struct bsem *bsem_p, int value);
+static void  bsem_reset(struct bsem *bsem_p);
+static void  bsem_post(struct bsem *bsem_p);
+static void  bsem_post_all(struct bsem *bsem_p);
+static void  bsem_wait(struct bsem *bsem_p);
+
+
+
+
+
+/* ========================== THREADPOOL ============================ */
+
+
+/* Initialise thread pool */
+struct thpool_* thpool_init(int num_threads){
+
+    threads_on_hold   = 0;
+    threads_keepalive = 1;
+
+    if (num_threads < 0){
+        num_threads = 0;
+    }
+
+    /* Make new thread pool */
+    thpool_* thpool_p;
+    thpool_p = (struct thpool_*)malloc(sizeof(struct thpool_));
+    if (thpool_p == NULL){
+        err("thpool_init(): Could not allocate memory for thread pool\n");
+        return NULL;
+    }
+    thpool_p->num_threads_alive   = 0;
+    thpool_p->num_threads_working = 0;
+
+    /* Initialise the job queue */
+    if (jobqueue_init(&thpool_p->jobqueue) == -1){
+        err("thpool_init(): Could not allocate memory for job queue\n");
+        free(thpool_p);
+        return NULL;
+    }
+
+    /* Make threads in pool */
+    thpool_p->threads = (struct thread**)malloc(num_threads * sizeof(struct thread *));
+    if (thpool_p->threads == NULL){
+        err("thpool_init(): Could not allocate memory for threads\n");
+        jobqueue_destroy(&thpool_p->jobqueue);
+        free(thpool_p);
+        return NULL;
+    }
+
+    pthread_mutex_init(&(thpool_p->thcount_lock), NULL);
+    pthread_cond_init(&thpool_p->threads_all_idle, NULL);
+
+    /* Thread init */
+    int n;
+    for (n=0; n<num_threads; n++){
+        thread_init(thpool_p, &thpool_p->threads[n], n);
+#if THPOOL_DEBUG
+            printf("THPOOL_DEBUG: Created thread %d in pool \n", n);
+#endif
+    }
+
+    /* Wait for threads to initialize */
+    while (thpool_p->num_threads_alive != num_threads) {}
+
+    return thpool_p;
+}
+
+
+/* Add work to the thread pool */
+int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
+    job* newjob;
+
+    newjob=(struct job*)malloc(sizeof(struct job));
+    if (newjob==NULL){
+        err("thpool_add_work(): Could not allocate memory for new job\n");
+        return -1;
+    }
+
+    /* add function and argument */
+    newjob->function=function_p;
+    newjob->arg=arg_p;
+
+    /* add job to queue */
+    jobqueue_push(&thpool_p->jobqueue, newjob);
+
+    return 0;
+}
+
+
+/* Wait until all jobs have finished */
+void thpool_wait(thpool_* thpool_p){
+    pthread_mutex_lock(&thpool_p->thcount_lock);
+    while (thpool_p->jobqueue.len || thpool_p->num_threads_working) {
+        pthread_cond_wait(&thpool_p->threads_all_idle, &thpool_p->thcount_lock);
+    }
+    pthread_mutex_unlock(&thpool_p->thcount_lock);
+}
+
+
+/* Destroy the threadpool */
+void thpool_destroy(thpool_* thpool_p){
+    /* No need to destory if it's NULL */
+    if (thpool_p == NULL) return ;
+
+    volatile int threads_total = thpool_p->num_threads_alive;
+
+    /* End each thread 's infinite loop */
+    threads_keepalive = 0;
+
+    /* Give one second to kill idle threads */
+    double TIMEOUT = 1.0;
+    time_t start, end;
+    double tpassed = 0.0;
+    time (&start);
+    while (tpassed < TIMEOUT && thpool_p->num_threads_alive){
+        bsem_post_all(thpool_p->jobqueue.has_jobs);
+        time (&end);
+        tpassed = difftime(end,start);
+    }
+
+    /* Poll remaining threads */
+    while (thpool_p->num_threads_alive){
+        bsem_post_all(thpool_p->jobqueue.has_jobs);
+        sleep(1);
+    }
+
+    /* Job queue cleanup */
+    jobqueue_destroy(&thpool_p->jobqueue);
+    /* Deallocs */
+    int n;
+    for (n=0; n < threads_total; n++){
+        thread_destroy(thpool_p->threads[n]);
+    }
+    free(thpool_p->threads);
+    free(thpool_p);
+}
+
+
+/* Pause all threads in threadpool */
+void thpool_pause(thpool_* thpool_p) {
+    int n;
+    for (n=0; n < thpool_p->num_threads_alive; n++){
+        pthread_kill(thpool_p->threads[n]->pthread, SIGUSR1);
+    }
+}
+
+
+/* Resume all threads in threadpool */
+void thpool_resume(thpool_* thpool_p) {
+    // resuming a single threadpool hasn't been
+    // implemented yet, meanwhile this supresses
+    // the warnings
+    (void)thpool_p;
+
+    threads_on_hold = 0;
+}
+
+
+int thpool_num_threads_working(thpool_* thpool_p){
+    return thpool_p->num_threads_working;
+}
+
+
+
+
+
+/* ============================ THREAD ============================== */
+
+
+/* Initialize a thread in the thread pool
+ *
+ * @param thread        address to the pointer of the thread to be created
+ * @param id            id to be given to the thread
+ * @return 0 on success, -1 otherwise.
+ */
+static int thread_init (thpool_* thpool_p, struct thread** thread_p, int id){
+
+    *thread_p = (struct thread*)malloc(sizeof(struct thread));
+    if (thread_p == NULL){
+        err("thread_init(): Could not allocate memory for thread\n");
+        return -1;
+    }
+
+    (*thread_p)->thpool_p = thpool_p;
+    (*thread_p)->id       = id;
+
+    pthread_create(&(*thread_p)->pthread, NULL, (void *)thread_do, (*thread_p));
+    pthread_detach((*thread_p)->pthread);
+    return 0;
+}
+
+
+/* Sets the calling thread on hold */
+static void thread_hold(int sig_id) {
+    (void)sig_id;
+    threads_on_hold = 1;
+    while (threads_on_hold){
+        sleep(1);
+    }
+}
+
+
+/* What each thread is doing
+*
+* In principle this is an endless loop. The only time this loop gets interuppted is once
+* thpool_destroy() is invoked or the program exits.
+*
+* @param  thread        thread that will run this function
+* @return nothing
+*/
+static void* thread_do(struct thread* thread_p){
+
+    /* Set thread name for profiling and debuging */
+    char thread_name[128] = {0};
+    sprintf(thread_name, "thread-pool-%d", thread_p->id);
+
+#if defined(__linux__)
+    /* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */
+    prctl(PR_SET_NAME, thread_name);
+#elif defined(__APPLE__) && defined(__MACH__)
+    pthread_setname_np(thread_name);
+#else
+    err("thread_do(): pthread_setname_np is not supported on this system");
+#endif
+
+    /* Assure all threads have been created before starting serving */
+    thpool_* thpool_p = thread_p->thpool_p;
+
+    /* Register signal handler */
+    struct sigaction act;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = 0;
+    act.sa_handler = thread_hold;
+    if (sigaction(SIGUSR1, &act, NULL) == -1) {
+        err("thread_do(): cannot handle SIGUSR1");
+    }
+
+    /* Mark thread as alive (initialized) */
+    pthread_mutex_lock(&thpool_p->thcount_lock);
+    thpool_p->num_threads_alive += 1;
+    pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+    while(threads_keepalive){
+
+        bsem_wait(thpool_p->jobqueue.has_jobs);
+
+        if (threads_keepalive){
+
+            pthread_mutex_lock(&thpool_p->thcount_lock);
+            thpool_p->num_threads_working++;
+            pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+            /* Read job from queue and execute it */
+            void (*func_buff)(void*);
+            void*  arg_buff;
+            job* job_p = jobqueue_pull(&thpool_p->jobqueue);
+            if (job_p) {
+                func_buff = job_p->function;
+                arg_buff  = job_p->arg;
+                func_buff(arg_buff);
+                free(job_p);
+            }
+
+            pthread_mutex_lock(&thpool_p->thcount_lock);
+            thpool_p->num_threads_working--;
+            if (!thpool_p->num_threads_working) {
+                pthread_cond_signal(&thpool_p->threads_all_idle);
+            }
+            pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+        }
+    }
+    pthread_mutex_lock(&thpool_p->thcount_lock);
+    thpool_p->num_threads_alive --;
+    pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+    return NULL;
+}
+
+
+/* Frees a thread  */
+static void thread_destroy (thread* thread_p){
+    free(thread_p);
+}
+
+
+
+
+
+/* ============================ JOB QUEUE =========================== */
+
+
+/* Initialize queue */
+static int jobqueue_init(jobqueue* jobqueue_p){
+    jobqueue_p->len = 0;
+    jobqueue_p->front = NULL;
+    jobqueue_p->rear  = NULL;
+
+    jobqueue_p->has_jobs = (struct bsem*)malloc(sizeof(struct bsem));
+    if (jobqueue_p->has_jobs == NULL){
+        return -1;
+    }
+
+    pthread_mutex_init(&(jobqueue_p->rwmutex), NULL);
+    bsem_init(jobqueue_p->has_jobs, 0);
+
+    return 0;
+}
+
+
+/* Clear the queue */
+static void jobqueue_clear(jobqueue* jobqueue_p){
+
+    while(jobqueue_p->len){
+        free(jobqueue_pull(jobqueue_p));
+    }
+
+    jobqueue_p->front = NULL;
+    jobqueue_p->rear  = NULL;
+    bsem_reset(jobqueue_p->has_jobs);
+    jobqueue_p->len = 0;
+
+}
+
+
+/* Add (allocated) job to queue
+ */
+static void jobqueue_push(jobqueue* jobqueue_p, struct job* newjob){
+
+    pthread_mutex_lock(&jobqueue_p->rwmutex);
+    newjob->prev = NULL;
+
+    switch(jobqueue_p->len){
+
+        case 0:  /* if no jobs in queue */
+                    jobqueue_p->front = newjob;
+                    jobqueue_p->rear  = newjob;
+                    break;
+
+        default: /* if jobs in queue */
+                    jobqueue_p->rear->prev = newjob;
+                    jobqueue_p->rear = newjob;
+
+    }
+    jobqueue_p->len++;
+
+    bsem_post(jobqueue_p->has_jobs);
+    pthread_mutex_unlock(&jobqueue_p->rwmutex);
+}
+
+
+/* Get first job from queue(removes it from queue)
+<<<<<<< HEAD
+ *
+ * Notice: Caller MUST hold a mutex
+=======
+>>>>>>> da2c0fe45e43ce0937f272c8cd2704bdc0afb490
+ */
+static struct job* jobqueue_pull(jobqueue* jobqueue_p){
+
+    pthread_mutex_lock(&jobqueue_p->rwmutex);
+    job* job_p = jobqueue_p->front;
+
+    switch(jobqueue_p->len){
+
+        case 0:  /* if no jobs in queue */
+                    break;
+
+        case 1:  /* if one job in queue */
+                    jobqueue_p->front = NULL;
+                    jobqueue_p->rear  = NULL;
+                    jobqueue_p->len = 0;
+                    break;
+
+        default: /* if >1 jobs in queue */
+                    jobqueue_p->front = job_p->prev;
+                    jobqueue_p->len--;
+                    /* more than one job in queue -> post it */
+                    bsem_post(jobqueue_p->has_jobs);
+
+    }
+
+    pthread_mutex_unlock(&jobqueue_p->rwmutex);
+    return job_p;
+}
+
+
+/* Free all queue resources back to the system */
+static void jobqueue_destroy(jobqueue* jobqueue_p){
+    jobqueue_clear(jobqueue_p);
+    free(jobqueue_p->has_jobs);
+}
+
+
+
+
+
+/* ======================== SYNCHRONISATION ========================= */
+
+
+/* Init semaphore to 1 or 0 */
+static void bsem_init(bsem *bsem_p, int value) {
+    if (value < 0 || value > 1) {
+        err("bsem_init(): Binary semaphore can take only values 1 or 0");
+        exit(1);
+    }
+    pthread_mutex_init(&(bsem_p->mutex), NULL);
+    pthread_cond_init(&(bsem_p->cond), NULL);
+    bsem_p->v = value;
+}
+
+
+/* Reset semaphore to 0 */
+static void bsem_reset(bsem *bsem_p) {
+    bsem_init(bsem_p, 0);
+}
+
+
+/* Post to at least one thread */
+static void bsem_post(bsem *bsem_p) {
+    pthread_mutex_lock(&bsem_p->mutex);
+    bsem_p->v = 1;
+    pthread_cond_signal(&bsem_p->cond);
+    pthread_mutex_unlock(&bsem_p->mutex);
+}
+
+
+/* Post to all threads */
+static void bsem_post_all(bsem *bsem_p) {
+    pthread_mutex_lock(&bsem_p->mutex);
+    bsem_p->v = 1;
+    pthread_cond_broadcast(&bsem_p->cond);
+    pthread_mutex_unlock(&bsem_p->mutex);
+}
+
+
+/* Wait on semaphore until semaphore has value 0 */
+static void bsem_wait(bsem* bsem_p) {
+    pthread_mutex_lock(&bsem_p->mutex);
+    while (bsem_p->v != 1) {
+        pthread_cond_wait(&bsem_p->cond, &bsem_p->mutex);
+    }
+    bsem_p->v = 0;
+    pthread_mutex_unlock(&bsem_p->mutex);
+}

--- a/benchmark/thpool_old.h
+++ b/benchmark/thpool_old.h
@@ -1,0 +1,187 @@
+/**********************************
+ * @author      Johan Hanssen Seferidis
+ * License:     MIT
+ *
+ **********************************/
+
+#ifndef _THPOOL_
+#define _THPOOL_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =================================== API ======================================= */
+
+
+typedef struct thpool_* threadpool;
+
+
+/**
+ * @brief  Initialize threadpool
+ *
+ * Initializes a threadpool. This function will not return untill all
+ * threads have initialized successfully.
+ *
+ * @example
+ *
+ *    ..
+ *    threadpool thpool;                     //First we declare a threadpool
+ *    thpool = thpool_init(4);               //then we initialize it to 4 threads
+ *    ..
+ *
+ * @param  num_threads   number of threads to be created in the threadpool
+ * @return threadpool    created threadpool on success,
+ *                       NULL on error
+ */
+threadpool thpool_init(int num_threads);
+
+
+/**
+ * @brief Add work to the job queue
+ *
+ * Takes an action and its argument and adds it to the threadpool's job queue.
+ * If you want to add to work a function with more than one arguments then
+ * a way to implement this is by passing a pointer to a structure.
+ *
+ * NOTICE: You have to cast both the function and argument to not get warnings.
+ *
+ * @example
+ *
+ *    void print_num(int num){
+ *       printf("%d\n", num);
+ *    }
+ *
+ *    int main() {
+ *       ..
+ *       int a = 10;
+ *       thpool_add_work(thpool, (void*)print_num, (void*)a);
+ *       ..
+ *    }
+ *
+ * @param  threadpool    threadpool to which the work will be added
+ * @param  function_p    pointer to function to add as work
+ * @param  arg_p         pointer to an argument
+ * @return 0 on successs, -1 otherwise.
+ */
+int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
+
+
+/**
+ * @brief Wait for all queued jobs to finish
+ *
+ * Will wait for all jobs - both queued and currently running to finish.
+ * Once the queue is empty and all work has completed, the calling thread
+ * (probably the main program) will continue.
+ *
+ * Smart polling is used in wait. The polling is initially 0 - meaning that
+ * there is virtually no polling at all. If after 1 seconds the threads
+ * haven't finished, the polling interval starts growing exponentially
+ * untill it reaches max_secs seconds. Then it jumps down to a maximum polling
+ * interval assuming that heavy processing is being used in the threadpool.
+ *
+ * @example
+ *
+ *    ..
+ *    threadpool thpool = thpool_init(4);
+ *    ..
+ *    // Add a bunch of work
+ *    ..
+ *    thpool_wait(thpool);
+ *    puts("All added work has finished");
+ *    ..
+ *
+ * @param threadpool     the threadpool to wait for
+ * @return nothing
+ */
+void thpool_wait(threadpool);
+
+
+/**
+ * @brief Pauses all threads immediately
+ *
+ * The threads will be paused no matter if they are idle or working.
+ * The threads return to their previous states once thpool_resume
+ * is called.
+ *
+ * While the thread is being paused, new work can be added.
+ *
+ * @example
+ *
+ *    threadpool thpool = thpool_init(4);
+ *    thpool_pause(thpool);
+ *    ..
+ *    // Add a bunch of work
+ *    ..
+ *    thpool_resume(thpool); // Let the threads start their magic
+ *
+ * @param threadpool    the threadpool where the threads should be paused
+ * @return nothing
+ */
+void thpool_pause(threadpool);
+
+
+/**
+ * @brief Unpauses all threads if they are paused
+ *
+ * @example
+ *    ..
+ *    thpool_pause(thpool);
+ *    sleep(10);              // Delay execution 10 seconds
+ *    thpool_resume(thpool);
+ *    ..
+ *
+ * @param threadpool     the threadpool where the threads should be unpaused
+ * @return nothing
+ */
+void thpool_resume(threadpool);
+
+
+/**
+ * @brief Destroy the threadpool
+ *
+ * This will wait for the currently active threads to finish and then 'kill'
+ * the whole threadpool to free up memory.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    thpool_destroy(thpool1);
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool to destroy
+ * @return nothing
+ */
+void thpool_destroy(threadpool);
+
+
+/**
+ * @brief Show currently working threads
+ *
+ * Working threads are the threads that are performing work (not idle).
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    printf("Working threads: %d\n", thpool_num_threads_working(thpool1));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       number of threads working
+ */
+int thpool_num_threads_working(threadpool);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/api.sh
+++ b/tests/api.sh
@@ -5,7 +5,10 @@
 # works to an acceptable standard.
 #
 
-. funcs.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/funcs.sh
 
 
 # ---------------------------- Tests -----------------------------------
@@ -13,8 +16,8 @@
 
 function test_api {
 	echo "Testing API calls.."
-	compile src/api.c
-	output=`./test`
+	compile $DIR/src/api.c
+	output=`$DIR/test`
 	if [[ $? != 0 ]]; then
 		 err "$output" "$output"
 		 exit 1

--- a/tests/funcs.sh
+++ b/tests/funcs.sh
@@ -5,6 +5,9 @@
 # want to use any of the functions
 #
 
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
 function assure_installed_valgrind {
     valgrind --version &> /dev/null
     if (( $? != 0 )); then
@@ -42,11 +45,11 @@ function time_exec { #command ..
 function err { #string #log
 	echo "------------------- ERROR ------------------------"
 	echo "$1"
-	echo "$2" >> error.log
+	echo "$2" >> $DIR/error.log
 	exit 1
 }
 
 
 function compile { #cfilepath
-	gcc $COMPILATION_FLAGS "$1" ../thpool.c -D THPOOL_DEBUG -pthread -o test
+	gcc $COMPILATION_FLAGS "$1" $DIR/../thpool.c -D THPOOL_DEBUG -pthread -o $DIR/test
 }

--- a/tests/heap_stack_garbage.sh
+++ b/tests/heap_stack_garbage.sh
@@ -4,15 +4,18 @@
 # This file tests for possible bugs
 #
 
-. funcs.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/funcs.sh
 
 
 # ---------------------------- Tests -----------------------------------
 
 function test_with_nonzero_heap_and_stack {
-    compile src/nonzero_heap_stack.c
+    compile $DIR/src/nonzero_heap_stack.c
     echo "Testing for non-zero heap and stack"
-    output=$(timeout 1 ./test)
+    output=$(timeout 1 $DIR/test)
     if [[ $? != 0 ]]; then
         err "Fail running on nonzero heap and stack" "$output"
         exit 1

--- a/tests/normal_compile.sh
+++ b/tests/normal_compile.sh
@@ -8,11 +8,14 @@
 
 # ---------------------------- Tests -----------------------------------
 
-. threadpool.sh
-. api.sh
-. pause_resume.sh
-. heap_stack_garbage.sh
-. memleaks.sh
-. wait.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/threadpool.sh
+. $DIR/api.sh
+. $DIR/pause_resume.sh
+. $DIR/heap_stack_garbage.sh
+. $DIR/memleaks.sh
+. $DIR/wait.sh
 
 echo "No errors"

--- a/tests/optimized_compile.sh
+++ b/tests/optimized_compile.sh
@@ -9,7 +9,10 @@
 
 # ---------------------------- Tests -----------------------------------
 
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
 COMPILATION_FLAGS='-g -O'
-. normal_compile.sh
+. $DIR/normal_compile.sh
 
 echo "No optimization errors"

--- a/tests/pause_resume.sh
+++ b/tests/pause_resume.sh
@@ -5,7 +5,10 @@
 # valgrind is used so make sure you have it installed
 #
 
-. funcs.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/funcs.sh
 
 
 # ---------------------------- Tests -----------------------------------
@@ -13,8 +16,8 @@
 
 function test_pause_resume_est7secs { #threads
 	echo "Pause and resume test for 7 secs with $1 threads"
-	compile src/pause_resume.c
-	realsecs=$(/usr/bin/time -f '%e' ./test "$1" 2>&1 > /dev/null)
+	compile $DIR/src/pause_resume.c
+	realsecs=$(/usr/bin/time -f '%e' $DIR/test "$1" 2>&1 > /dev/null)
 	threshold=1.00 # in secs
 	
 	ret=$(python -c "print(($realsecs-7)<=$threshold)")

--- a/tests/src/api.c
+++ b/tests/src/api.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]){
 	threadpool thpool;
 
 	/* Test if we can get the current number of working threads */
-	thpool = thpool_init(10);
+	thpool = thpool_init(10, 4);
 	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
 	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
 	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]){
 	};
 
 	/* Test (same as above) */
-	thpool = thpool_init(5);
+	thpool = thpool_init(5, 2);
 	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
 	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
 	sleep(1);

--- a/tests/src/conc_increment.c
+++ b/tests/src/conc_increment.c
@@ -20,13 +20,13 @@ int main(int argc, char *argv[]){
 	
 	char* p;
 	if (argc != 3){
-		puts("This testfile needs excactly two arguments");
+		puts("This testfile needs exactly two arguments");
 		exit(1);
 	}
 	int num_jobs    = strtol(argv[1], &p, 10);
 	int num_threads = strtol(argv[2], &p, 10);
 
-	threadpool thpool = thpool_init(num_threads);
+	threadpool thpool = thpool_init(num_threads, num_jobs);
 	
 	int n;
 	for (n=0; n<num_jobs; n++){

--- a/tests/src/no_work.c
+++ b/tests/src/no_work.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]){
 	}
 	int num_threads = strtol(argv[1], &p, 10);
 
-	threadpool thpool = thpool_init(num_threads);
+	threadpool thpool = thpool_init(num_threads, num_threads);
 	thpool_destroy(thpool);
 
 	sleep(1); // Sometimes main exits before thpool_destroy finished 100%

--- a/tests/src/nonzero_heap_stack.c
+++ b/tests/src/nonzero_heap_stack.c
@@ -41,7 +41,7 @@ int main(){
 	nonzero_heap();
 
 	puts("Making threadpool with 4 threads");
-	threadpool thpool = thpool_init(4);
+	threadpool thpool = thpool_init(4, 20);
 
 	puts("Adding 20 tasks to threadpool");
 	int i;

--- a/tests/src/pause_resume.c
+++ b/tests/src/pause_resume.c
@@ -24,12 +24,12 @@ int main(int argc, char *argv[]){
 
 	char* p;
 	if (argc != 2){
-		puts("This testfile needs excactly one arguments");
+		puts("This testfile needs exactly one arguments");
 		exit(1);
 	}
 	int num_threads = strtol(argv[1], &p, 10);
 
-	threadpool thpool = thpool_init(num_threads);
+	threadpool thpool = thpool_init(num_threads, num_threads);
 	
 	thpool_pause(thpool);
 	

--- a/tests/src/wait.c
+++ b/tests/src/wait.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]){
 	int wait_each_job    = argv[3] ? strtol(argv[3], &p, 10) : 0;
 	int sleep_per_thread = argv[4] ? strtol(argv[4], &p, 10) : 1;
 
-	threadpool thpool = thpool_init(num_threads);
+	threadpool thpool = thpool_init(num_threads, num_jobs);
 
 	int n;
 	for (n=0; n<num_jobs; n++){

--- a/tests/threadpool.sh
+++ b/tests/threadpool.sh
@@ -5,13 +5,16 @@
 # might use in his/her code
 #
 
-. funcs.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/funcs.sh
 
 
 function test_mass_addition { #endsum #threads
 	echo "Adding up to $1 with $2 threads"
-	compile src/conc_increment.c
-	output=$(./test $1 $2)
+	compile $DIR/src/conc_increment.c
+	output=$($DIR/test $1 $2)
 	num=$(echo $output | awk '{print $(NF)}')
 	if [ "$num" == "$1" ]; then
 		return
@@ -23,7 +26,7 @@ function test_mass_addition { #endsum #threads
 
 # Run tests
 test_mass_addition 100 4
-test_mass_addition 100 1000
-test_mass_addition 100000 1000
+test_mass_addition 100 100
+test_mass_addition 100000 100
 
 echo "No errors"

--- a/tests/wait.sh
+++ b/tests/wait.sh
@@ -5,7 +5,10 @@
 # valgrind is used so make sure you have it installed
 #
 
-. funcs.sh
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. $DIR/funcs.sh
 
 
 # ---------------------------- Tests -----------------------------------
@@ -13,8 +16,8 @@
 
 function test_wait_each_job { #threads #jobs
 	echo "Will test waiting for each job ($1 threads, $2 jobs)"
-	compile src/wait.c
-	realsecs=$(time_exec ./test $2 $1 1)
+	compile $DIR/src/wait.c
+	realsecs=$(time_exec $DIR/test $2 $1 1)
 	threshold=1.00 # in secs
 
 	ret=$(python -c "print((abs($realsecs-$2))<=$threshold)")
@@ -29,8 +32,8 @@ function test_wait_each_job { #threads #jobs
 
 function test_wait_pool { #threads #jobs
 	echo "Will test waiting for whole threadpool ($1 threads, $2 jobs)"
-	compile src/wait.c
-	realsecs=$(time_exec ./test $2 $1 0)
+	compile $DIR/src/wait.c
+	realsecs=$(time_exec $DIR/test $2 $1 0)
 	threshold=1.00 # in secs
 	
 	expected_time=$(python -c "import math; print(math.ceil($2/$1.0))")

--- a/thpool.c
+++ b/thpool.c
@@ -53,7 +53,6 @@ typedef struct job{
 /* Job pool */
 typedef struct jobpool{
     job *front;                          /* pointer to front of pool  */
-    int available_jobs;                  /* check if more are needed  */
     pthread_mutex_t lock;                /* used for job count etc    */
 } jobpool;
 
@@ -273,6 +272,18 @@ void thpool_resume(thpool_* thpool_p) {
 
 int thpool_num_threads_working(thpool_* thpool_p){
 	return thpool_p->num_threads_working;
+}
+
+
+int thpool_num_jobs_pooled(thpool_* thpool_p){
+    pthread_mutex_lock(&thpool_p->jobpool.lock);
+    int result = 0;
+    struct job *cur = thpool_p->jobpool.front;
+    while(cur != NULL){
+        result++;
+        cur = cur->prev;
+    }
+    pthread_mutex_unlock(&thpool_p->jobpool.lock);
 }
 
 

--- a/thpool.c
+++ b/thpool.c
@@ -284,6 +284,7 @@ int thpool_num_jobs_pooled(thpool_* thpool_p){
         cur = cur->prev;
     }
     pthread_mutex_unlock(&thpool_p->jobpool.lock);
+    return result;
 }
 
 

--- a/thpool.h
+++ b/thpool.h
@@ -7,6 +7,8 @@
 #ifndef _THPOOL_
 #define _THPOOL_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,7 +44,7 @@ typedef struct thpool_* threadpool;
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(unsigned num_threads, unsigned num_jobs);
+threadpool thpool_init(size_t num_threads, size_t num_jobs);
 
 
 /**

--- a/thpool.h
+++ b/thpool.h
@@ -188,6 +188,35 @@ void thpool_destroy(threadpool);
 int thpool_num_threads_working(threadpool);
 
 
+/**
+ * @brief Show currently pooled jobs.
+ *
+ * Pooled jobs are the ones sitting quietly in the pool,
+ * not queued and not being worked on.
+ *
+ * Might be useful to fine tune how many jobs you need
+ * to setup initially for certain tasks.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2, 3);
+ *    threadpool thpool2 = thpool_init(2, 10);
+ *    ...
+ *    // do your thing here
+ *    ...
+ *    thpool_wait(thpool1);
+ *    thpool_wait(thpool2);
+ *    printf("Jobs in pool: %d\n", thpool_num_jobs_pooled(thpool1));  // prints 3
+ *    printf("Jobs in pool: %d\n", thpool_num_jobs_pooled(thpool2));  // prints 10
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       number of jobs in pool
+ */
+int thpool_num_jobs_pooled(threadpool);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/thpool.h
+++ b/thpool.h
@@ -34,7 +34,7 @@ typedef struct thpool_* threadpool;
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(int num_threads);
+threadpool thpool_init(unsigned num_threads, unsigned num_jobs);
 
 
 /**

--- a/thpool.h
+++ b/thpool.h
@@ -20,17 +20,25 @@ typedef struct thpool_* threadpool;
 /**
  * @brief  Initialize threadpool
  *
- * Initializes a threadpool. This function will not return untill all
+ * Initializes a threadpool. This function will not return until all
  * threads have initialized successfully.
+ *
+ * The arguments refer to the number of threads that will exist in
+ * the pool and to the number of jobs that will be initially created
+ * in the pool. Please note that, if necessary due to workload, more
+ * jobs will be created and added to the pool dinamically to fulfill 
+ * that need.
  *
  * @example
  *
  *    ..
  *    threadpool thpool;                     //First we declare a threadpool
- *    thpool = thpool_init(4);               //then we initialize it to 4 threads
+ *    thpool = thpool_init(4, 0);            //then we initialize the pool to 
+ *                                           // 4 threads and 0 jobs
  *    ..
  *
  * @param  num_threads   number of threads to be created in the threadpool
+ * @param  num_jobs      number of jobs to be initially created in the threadpool
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */


### PR DESCRIPTION
Added a job pool to serve `thpool_add_work()`. Instead of creating and destroying jobs at will, a job pool is used to recycle and reuse jobs.

This massively improves performance where there is a high amount of tasks (On my system - which is pretty poor tbh - with about 5 million tasks it went from ~2.5s to ~1s).

`thpool_init()` now requires a second argument. Unfortunately there no defaults for arguments in C, so I can see no other way around it.

Documentation has also been updated in regards to the job pool. I'm pretty bad at explaining things so if further changes are required just say so.

`THPOOL_DEBUG` definitions have also been removed since they're no longer used. `thpool_init()` arguments are now of type `unsigned` to remove that unneeded check.

Finally, tests have been updated to use the new API. Accidentally I also included the changes I made to make them run from anywhere (instead of having to `cd tests/` first) and to make them run a little bit faster (the originals took 8 hours on my laptop, now they only take 3). I only noticed these were included after pushing but if necessary I can try to rebase them out of the pr.