### PR TITLE
Fix gcc warnings.

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -93,7 +93,7 @@ typedef struct thpool_{
 
 static int  thread_init(thpool_* thpool_p, struct thread** thread_p, int id);
 static void* thread_do(struct thread* thread_p);
-static void  thread_hold();
+static void  thread_hold(int sig_id);
 static void  thread_destroy(struct thread* thread_p);
 
 static int   jobqueue_init(jobqueue* jobqueue_p);
@@ -251,6 +251,7 @@ void thpool_pause(thpool_* thpool_p) {
 
 /* Resume all threads in threadpool */
 void thpool_resume(thpool_* thpool_p) {
+    (void)thpool_p;
 	threads_on_hold = 0;
 }
 
@@ -290,7 +291,8 @@ static int thread_init (thpool_* thpool_p, struct thread** thread_p, int id){
 
 
 /* Sets the calling thread on hold */
-static void thread_hold () {
+static void thread_hold(int sig_id) {
+    (void)sig_id;
 	threads_on_hold = 1;
 	while (threads_on_hold){
 		sleep(1);

--- a/thpool.c
+++ b/thpool.c
@@ -251,7 +251,11 @@ void thpool_pause(thpool_* thpool_p) {
 
 /* Resume all threads in threadpool */
 void thpool_resume(thpool_* thpool_p) {
+    // resuming a single threadpool hasn't been
+    // implemented yet, meanwhile this supresses
+    // the warnings
     (void)thpool_p;
+
 	threads_on_hold = 0;
 }
 


### PR DESCRIPTION
Fixes the `not a prototype` warning that `thread_hold()` gives, fixes the `unused argument` that comes up after fixing the previous one and fixes the `unused argument` that `thpool_resumes()` gives.