### PR TITLE
Added CMake support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Cmake
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+# External Libs (via Cmake)
+lib/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(thpool)
+set(CMAKE_BUILD_TYPE Release)
+include(ExternalProject)
+
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+set(SOURCES ${CMAKE_SOURCE_DIR}/thpool.c)
+set(HEADERS ${CMAKE_SOURCE_DIR}/thpool.h)
+
+add_library(pool_shared SHARED ${SOURCES})
+set_target_properties(pool_shared PROPERTIES VERSION 1.0 SOVERSION 1)
+add_library(pool_static STATIC ${SOURCES})
+set_target_properties(pool_shared pool_static PROPERTIES OUTPUT_NAME thpool)
+target_link_libraries(pool_shared pool_static Threads::Threads)
+
+if(MSVC)
+  # Force to always compile with W4
+  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]" OR CMAKE_C_FLAGS MATCHES "/W[0-4]")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
+  endif()
+elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+  # Update if necessary
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wstrict-prototypes")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wstrict-prototypes")
+endif()
+
+install(TARGETS pool_shared pool_static DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ Then run the executable like this:
     ./example
 
 
+## Building with CMake
+
+While it is recommended to use the approach described above, this library also supports CMake builds,
+mainly for compatibility with other CMake builds and for users who end up using this in many projects.
+
+The only requirement is the `pthread` library. UNIX users should have it installed already and Windows
+users can get it either from the [Pthreads-Win32](https://www.sourceware.org/pthreads-win32/) project
+or, if they're using Mingw32/Cygwin, from their package managers.
+
+To build with CMake, clone this repository and `cd` into it's root folder. Run the following:
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This library should now be built in the `bin/` folder. To install it, simply:
+
+```
+sudo make install
+```
+
+MSVC users should look into CMake's documentation for their generator.
+
+
 ## Basic usage
 
 1. Include the header in your source file: `#include "thpool.h"`


### PR DESCRIPTION
Added support to building this library with cmake. I left it clear in the readme that it is still preferred to build the sources into the user's project but for other projects using cmake it is much easier to integrate this library this way.

I don't know much about windows so I left it at the user's discretion to grab the appropriate library from pthreads-win32 and to get the proper build commands from cmake docs. If preferred I can try to get the appropriate library from pthreads-win32 and try to learn the build commands for windows, though this will take some time. On every other platform (or if the user is using Mingw32/cygwin) the process is exactly what is in the readme.

The added gitignore file is a mixture of the default C gitignote and the default CMake gitignore files from github.