### PR TITLE
Added jobs_placed and jobs_done counters

### DIFF
--- a/tests/src/api.c
+++ b/tests/src/api.c
@@ -40,6 +40,29 @@ int main(int argc, char *argv[]){
 		return -1;
 	};
 
+	/* Test jobs placed and jobs done counters */
+	long count;
+	thpool = thpool_init(2);
+	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
+	sleep(1);
+	thpool_pause(thpool);
+	count = thpool_num_jobs_placed(thpool);
+	if(num !=2 ){
+		printf("Expected 2 jobs placed, got %ld", count);
+	}
+	count = thpool_num_jobs_done(thpool);
+	if(num != 0){
+		printf("Expected 0 jobs done, got %ld", count);
+	}
+	thpool_resume(thpool);
+
+	sleep(1);
+	count = thpool_num_jobs_done(thpool);
+	if(num !=2 ){
+		printf("Expected 2 jobs done, got %ld", count);
+	}
+
 	// thpool_destroy(thpool);
 
 	// sleep(1); // Sometimes main exits before thpool_destroy finished 100%

--- a/thpool.c
+++ b/thpool.c
@@ -84,6 +84,8 @@ typedef struct thpool_{
 	pthread_mutex_t  thcount_lock;       /* used for thread count etc */
 	pthread_cond_t  threads_all_idle;    /* signal to thpool_wait     */
 	jobqueue  jobqueue;                  /* job queue                 */
+	long num_jobs_placed;		     /* jobs already placed       */
+	long num_jobs_done;                  /* jobs already done         */
 } thpool_;
 
 
@@ -136,6 +138,8 @@ struct thpool_* thpool_init(int num_threads){
 	}
 	thpool_p->num_threads_alive   = 0;
 	thpool_p->num_threads_working = 0;
+	thpool_p->num_jobs_placed = 0;
+	thpool_p->num_jobs_done = 0;
 
 	/* Initialise the job queue */
 	if (jobqueue_init(&thpool_p->jobqueue) == -1){
@@ -188,6 +192,9 @@ int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
 
 	/* add job to queue */
 	jobqueue_push(&thpool_p->jobqueue, newjob);
+
+	/* increment the job placed count */
+	thpool_p->num_jobs_placed++;
 
 	return 0;
 }
@@ -266,8 +273,13 @@ int thpool_num_threads_working(thpool_* thpool_p){
 	return thpool_p->num_threads_working;
 }
 
+long thpool_num_jobs_placed(thpool_* thpool_p){
+	return thpool_p->num_jobs_placed;
+}
 
-
+long thpool_num_jobs_done(thpool_* thpool_p){
+	return thpool_p->num_jobs_done;
+}
 
 
 /* ============================ THREAD ============================== */
@@ -365,6 +377,8 @@ static void* thread_do(struct thread* thread_p){
 				arg_buff  = job_p->arg;
 				func_buff(arg_buff);
 				free(job_p);
+				/* increment the job done count */
+				thpool_p->num_jobs_done++;
 			}
 
 			pthread_mutex_lock(&thpool_p->thcount_lock);

--- a/thpool.h
+++ b/thpool.h
@@ -180,6 +180,51 @@ void thpool_destroy(threadpool);
 int thpool_num_threads_working(threadpool);
 
 
+/**
+ * @brief Show the total number of jobs placed, including finished and ongoing
+ *
+ * This is an always-increment counter, and it shows the total number of jobs
+ * that has been placed to a threadpool in its lifetime.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool = thpool_init(2);
+ * 
+ *    // Add bunch of work
+ *    ..
+ *    printf("Placed jobs: %d\n", thpool_num_jobs_placed(thpool));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return long          number of jobs placed to this pool from its inception
+ */
+long thpool_num_jobs_placed(threadpool);
+
+
+/**
+ * @brief Show currently finished jobs
+ *
+ * This is an always-increment counter which shows the total number of jobs
+ * that this threadpool has finished in its lifetime.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool = thpool_init(2);
+ *    
+ *    // Add bunch of work
+ *    ..
+ *    printf("Finished jobs: %ld\n", thpool_num_jobs_done(thpool));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       number of jobs done by the threadpool in its lifetime
+ */
+long thpool_num_jobs_done(threadpool);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This counters will help track the progress of the jobs placed on the
pool. After placing some jobs, one can easily check the progress of the
total work by

```
double progress = (thpool_num_jobs_done(thpool)/thpool_num_jobs_placed(thpool))*100;
```

These counters can also be used to control the job flow, i.e. one canget total number of waiting jobs at any time by doing

`long waiting_jobs = (thpool_num_jobs_placed(thpool) - thpool_num_jobs_done(thpool);`

and then using some conditions, the programmer can restrict addition ofnew jobs if it crosses a certain limit, can wait for termination of all jobs, etc.
One can also track the rate of execution of jobs in the pool by,

```
long waiting_jobs1 = ...;
sleep(1);
long waiting_jobs2 = ...;
long jobs_per_sec = waiting_jobs1 - waiting_jobs2;
```

These counters can be used in various other places also. 