### PR TITLE
Added `pthread_set_name_np` for FreeBSD and OpenBSD

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -19,6 +19,9 @@
 #if defined(__linux__)
 #include <sys/prctl.h>
 #endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <pthread_np.h>
+#endif
 
 #include "thpool.h"
 
@@ -325,6 +328,8 @@ static void* thread_do(struct thread* thread_p){
 	prctl(PR_SET_NAME, thread_name);
 #elif defined(__APPLE__) && defined(__MACH__)
 	pthread_setname_np(thread_name);
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+    pthread_set_name_np(thread_p->pthread, thread_name);
 #else
 	err("thread_do(): pthread_setname_np is not supported on this system");
 #endif


### PR DESCRIPTION
I noticed that for Linux and Mac there was a way to set the thread name, so I add the respective function call for FreeBSD and OpenBSD.

The semantic of `ptread_set_name_np` is similar to Mac's `pthread_setname_np`.

Although this function isn't POSIX, the semantic is the same both on OpenBSD and FreeBSD (documentation respectively [here](http://man.openbsd.org/pthread_set_name_np) and [here](https://www.freebsd.org/cgi/man.cgi?query=pthread_set_name_np)).

Tested on FreeBSD 11.1-RELEASE-p4 and OpenBSD 6.4