### PR TITLE
The application has to wait till all the jobs have finished their execution

### DIFF
--- a/example.c
+++ b/example.c
@@ -38,6 +38,8 @@ int main(){
 		thpool_add_work(thpool, (void*)task2, NULL);
 	};
 
+	puts("Waiting till all the jobs have completed");
+	thpool_wait(thpool);
 	puts("Killing threadpool");
 	thpool_destroy(thpool);
 	


### PR DESCRIPTION
In the example application ( example.c ) , a number of tasks are assigned to the thread pool and the program is not waiting till all the tasks are getting completed. This fix will solve the issue and make program wait till all the scheduled tasks completed.
After that, all threads are getting destroyed.