### PR TITLE
Use safe snprintf() instead of sprintf()

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -317,8 +317,8 @@ static void thread_hold(int sig_id) {
 static void* thread_do(struct thread* thread_p){
 
 	/* Set thread name for profiling and debuging */
-	char thread_name[128] = {0};
-	sprintf(thread_name, "thread-pool-%d", thread_p->id);
+	char thread_name[32] = {0};
+	snprintf(thread_name, 32, "thread-pool-%d", thread_p->id);
 
 #if defined(__linux__)
 	/* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */


### PR DESCRIPTION
The use of sprintf is considered unsafe. And besides being in this case not vulnerable, CI services such as deepcode.ai will send an annoying alert for projects using thpool, as in this example: https://www.deepcode.ai/app/gh/nil0x42/duplicut/47376326b7e1fe987d60d6244ad76b0bb0b4a9e9/_/%2Fsrc%2Fthpool.c/cpp%2Fdc%2FBufferOverflowUnsafeFunction/321/code

The buffer is also bigger than needed: even if `thread_p->id` were to be an uint64_max, the generated string would still fit in 31 bytes (`thread-pool-9223372036854775807`); so buffer was set to 32 bytes instead of 128