### PR TITLE
docs: fix simple typo, successs -> success

### DIFF
--- a/thpool.h
+++ b/thpool.h
@@ -62,7 +62,7 @@ threadpool thpool_init(int num_threads);
  * @param  threadpool    threadpool to which the work will be added
  * @param  function_p    pointer to function to add as work
  * @param  arg_p         pointer to an argument
- * @return 0 on successs, -1 otherwise.
+ * @return 0 on success, -1 otherwise.
  */
 int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
 


### PR DESCRIPTION
There is a small typo in thpool.h.

Should read `success` rather than `successs`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md