### PR TITLE
Fix error in FreeBSD

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -18,6 +18,8 @@
 #include <time.h>
 #if defined(__linux__)
 #include <sys/prctl.h>
+#elif defined(__FreeBSD__)
+#include <pthread_np.h>
 #endif
 
 #include "thpool.h"
@@ -325,6 +327,8 @@ static void* thread_do(struct thread* thread_p){
 	prctl(PR_SET_NAME, thread_name);
 #elif defined(__APPLE__) && defined(__MACH__)
 	pthread_setname_np(thread_name);
+#elif defined(__FreeBSD__)
+	pthread_set_name_np(pthread_self(), thread_name);
 #else
 	err("thread_do(): pthread_setname_np is not supported on this system");
 #endif


### PR DESCRIPTION
Fixes the error message "thread_do(): pthread_setname_np is not supported on this system" in FreeBSD. Tested on Linux and in a FreeBSD virtual machine.