### PR TITLE
fix: limit thread name length to 16bytes

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -317,8 +317,8 @@ static void thread_hold(int sig_id) {
 static void* thread_do(struct thread* thread_p){
 
 	/* Set thread name for profiling and debuging */
-	char thread_name[32] = {0};
-	snprintf(thread_name, 32, "thread-pool-%d", thread_p->id);
+	char thread_name[16] = {0};
+	snprintf(thread_name, 16, "thpool-%d", thread_p->id);
 
 #if defined(__linux__)
 	/* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */


### PR DESCRIPTION
Thread name should not exceed 16 bytes according to [prctl API documentation](https://man7.org/linux/man-pages/man2/prctl.2.html). 

       PR_SET_NAME (since Linux 2.6.9)
              Set the name of the calling thread, using the value in the
              location pointed to by (char *) arg2.  The name can be up
              to 16 bytes long, including the terminating null byte.
              (If the length of the string, including the terminating
              null byte, exceeds 16 bytes, the string is silently
              truncated.)  This is the same attribute that can be set
              via pthread_setname_np(3) and retrieved using
              pthread_getname_np(3).  The attribute is likewise
              accessible via /proc/self/task/[tid]/comm (see proc(5)),
              where [tid] is the thread ID of the calling thread, as
              returned by gettid(2).