### PR TITLE
fix: set the SA_ONSTACK flag

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -341,7 +341,7 @@ static void* thread_do(struct thread* thread_p){
 	/* Register signal handler */
 	struct sigaction act;
 	sigemptyset(&act.sa_mask);
-	act.sa_flags = 0;
+	act.sa_flags = SA_ONSTACK;
 	act.sa_handler = thread_hold;
 	if (sigaction(SIGUSR1, &act, NULL) == -1) {
 		err("thread_do(): cannot handle SIGUSR1");


### PR DESCRIPTION
Many virtual machines, [including Go VM](https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG), depend on signals using [`SA_ONSTACK `](https://man7.org/linux/man-pages/man2/sigaltstack.2.html). This flag allows a thread to define a new alternate signal stack. Many argue that `SA_ONSTACK` should be a default, but it's not the case (yet).

This patch sets the `SA_ONSTACK` flag when C-Thread-Pool calls `sigaction()`.

Python merged a similar patch (https://github.com/python/cpython/pull/24730) in 2021 (Python 3.10+) for [the same reasons](https://bugs.python.org/issue43390), and [I did a similar patch for PHP](https://github.com/php/php-src/pull/9597), with no issues.