### PR TITLE
fix: properly destroy mutex during reset

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -520,6 +520,8 @@ static void bsem_init(bsem *bsem_p, int value) {
 
 /* Reset semaphore to 0 */
 static void bsem_reset(bsem *bsem_p) {
+	pthread_mutex_destroy(&(bsem_p->mutex));
+	pthread_cond_destroy(&(bsem_p->cond));
 	bsem_init(bsem_p, 0);
 }
 


### PR DESCRIPTION
Not destroying the mutex and the cond before initializing it again has undefined behavior. This causes crashes under some conditions, especially on Mac: https://github.com/dunglas/frankenphp/pull/394

This patch fixes the problem.

Closes https://github.com/Pithikos/C-Thread-Pool/issues/120.