### PR TITLE
fix: ensure that SA_ONSTACK is declared

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -14,6 +14,9 @@
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
 #endif
 #include <unistd.h>
 #include <signal.h>

--- a/thpool.c
+++ b/thpool.c
@@ -349,7 +349,7 @@ static void* thread_do(struct thread* thread_p){
 	/* Register signal handler */
 	struct sigaction act;
 	sigemptyset(&act.sa_mask);
-	act.sa_flags = 0;
+	act.sa_flags = SA_ONSTACK;
 	act.sa_handler = thread_hold;
 	if (sigaction(SIGUSR1, &act, NULL) == -1) {
 		err("thread_do(): cannot handle SIGUSR1");


### PR DESCRIPTION
Fixes an issue I introduced in https://github.com/Pithikos/C-Thread-Pool/pull/116.
Closes https://github.com/Pithikos/C-Thread-Pool/pull/127.