### PR TITLE
[BUGFIX] Fix thpool_destroy() hang: unlock all workers at once

### DIFF
--- a/tests/src/thpool_destroy_hang.c
+++ b/tests/src/thpool_destroy_hang.c
@@ -1,0 +1,55 @@
+/*
+ * Reproduces the “hang inside thpool_destroy()” bug.
+ *   – Fails (SIGALRM) with the original binary-semaphore implementation.
+ *   – Succeeds instantly once bsem_wait / bsem_post_all are patched.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/time.h>
+#include "../../thpool.h"
+
+#define TIMEOUT 1
+
+/* -------------------------------------------------------------- */
+/* 2. SIGALRM handler: triggers when thpool_destroy() does not    */
+/*    return within 1 sec, indicating the bug is reproduced.      */
+/* -------------------------------------------------------------- */
+static void timeout_handler(int sig)
+{
+    (void)sig;
+    fprintf(stderr,
+            "FAIL: thpool_destroy() did not finish within %d s "
+            "(bug reproduced)\n", TIMEOUT);
+    _exit(EXIT_FAILURE);
+}
+
+int main(void)
+{
+    const int THREADS = 4000;
+
+    /* Watchdog: if we are still alive after 3 s, the bug is present */
+    signal(SIGALRM, timeout_handler);
+    alarm(TIMEOUT);
+
+    printf("Creating pool with %d threads …\n", THREADS);
+    threadpool tp = thpool_init(THREADS);
+
+    struct timeval t0, t1;
+    gettimeofday(&t0, NULL);
+
+    printf("Calling thpool_destroy() …\n");
+    thpool_destroy(tp);      /* ← hangs here when not patched */
+
+    gettimeofday(&t1, NULL);
+    alarm(0); /* disarm watchdog */
+
+    double elapsed =
+        (t1.tv_sec - t0.tv_sec) + (t1.tv_usec - t0.tv_usec) / 1e6;
+
+    printf("PASS: thpool_destroy() returned in %.3f s (patch OK)\n",
+           elapsed);
+    return 0;
+}

--- a/tests/thpool_destroy_hang.sh
+++ b/tests/thpool_destroy_hang.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+#
+# Test for the deterministic thpool_destroy() hang
+#
+
+. funcs.sh
+
+# -------------------------------------------------- #
+# Single test: must finish without hitting SIGALRM   #
+# -------------------------------------------------- #
+function test_thpool_destroy_hang {
+    compile src/thpool_destroy_hang.c
+    echo "Testing for thpool_destroy() hang"
+    output=$(timeout 2 ./test)
+    if [[ $? != 0 ]]; then
+        err "thpool_destroy() hang reproduced" "$output"
+        exit 1
+    fi
+
+}
+
+# Run the test
+test_thpool_destroy_hang
+
+echo "No errors"

--- a/thpool.c
+++ b/thpool.c
@@ -25,6 +25,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <time.h>
+#include <limits.h>
 #if defined(__linux__)
 #include <sys/prctl.h>
 #endif
@@ -554,7 +555,7 @@ static void bsem_post(bsem *bsem_p) {
 /* Post to all threads */
 static void bsem_post_all(bsem *bsem_p) {
 	pthread_mutex_lock(&bsem_p->mutex);
-	bsem_p->v = 1;
+	bsem_p->v = INT_MAX;
 	pthread_cond_broadcast(&bsem_p->cond);
 	pthread_mutex_unlock(&bsem_p->mutex);
 }
@@ -563,9 +564,9 @@ static void bsem_post_all(bsem *bsem_p) {
 /* Wait on semaphore until semaphore has value 0 */
 static void bsem_wait(bsem* bsem_p) {
 	pthread_mutex_lock(&bsem_p->mutex);
-	while (bsem_p->v != 1) {
+	while (bsem_p->v == 0) {
 		pthread_cond_wait(&bsem_p->cond, &bsem_p->mutex);
 	}
-	bsem_p->v = 0;
+	bsem_p->v--;
 	pthread_mutex_unlock(&bsem_p->mutex);
 }


### PR DESCRIPTION
Hi, i'm nil0x42, the creator of [duplicut](https://github.com/nil0x42/duplicut/)
I wrote this patch for duplicut's copy of thpool.c, as i had a strange timeout in some unit tests that arised only once per ~1000 runs. 

### unblock *all* workers in thpool_destroy(), fix hang with medium-to-large pools

`thpool_destroy()` is supposed to wake every worker, wait until the pool
is empty, and return quickly.
In practice it can block for dozens of seconds as
soon as the pool size out-grows its one-second “fast-exit” window.

#### Root cause

* `bsem_post_all()` sets `v = 1` and broadcasts.
* The **first** worker that wakes executes
  `bsem_wait() → while (v==0) … ; v = 0; …`
  → the single ticket is consumed, all other awakened threads fall
  straight back into `pthread_cond_wait()`.
* After that first second, the destroy code slow-polls:
  one `bsem_post_all()` + `sleep(1)` per loop → **one ticket per
  second**.

With 4000 threads the destructor needs \~4000 s; even with only **16
threads** (real-world `duplicut` run) it can exceed a watchdog such as
`timeout 5`, hanging about 1 ‰ of the executions.

#### Fix (pure ANSI C / POSIX, no API change)

1. **`bsem_wait()`** now consumes *exactly one* ticket:

```c
/* take one ticket */
bsem_p->v--;
```

2. **`bsem_post_all()`** grants “infinite” tickets so every waiter can
   pass:

```c
bsem_p->v = INT_MAX;
pthread_cond_broadcast(&bsem_p->cond);
```

The single-post path (`bsem_post()`) is unchanged: one post still wakes
one thread.
All accesses to `v` remain protected by the semaphore mutex, so no new
data races or lock-order inversions are introduced.

#### Reproducer added

`tests/thpool_destroy_hang.sh`
`tests/src/thpool_destroy_hang.c`


```sh
cd tests/
./destroy_hang_deterministic.sh # hangs with old code, passes (<0.2 s) with patch
```

* 4000-thread pool hangs 100 % of the time without the patch.
* 16-thread pool matches the sporadic timeout seen in `duplicut`.

#### Impact

| Scenario                          |                before | after   |
| --------------------------------- | --------------------: | ------: |
| `thpool_destroy()` – 4000 threads |                 60 s+ |  170 ms |
| `duplicut` (16 threads)           | 1 ‰ hangs (timeout 5) |     0   |

The change makes pool shutdown reliable regardless of the thread count
and keeps behaviour identical in every other respect.
