### PR TITLE
Validate thread count in thpool_init() and return NULL for non-positi…

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -142,9 +142,10 @@ struct thpool_* thpool_init(int num_threads){
 	threads_on_hold   = 0;
 	threads_keepalive = 1;
 
-	if (num_threads < 0){
-		num_threads = 0;
-	}
+	if (num_threads <= 0){
+        err("thpool_init(): thread count must be > 0\n");
+        return NULL;
+    }
 
 	/* Make new thread pool */
 	thpool_* thpool_p;


### PR DESCRIPTION
This pull request adds a sanity check to thpool_init() to ensure that the number of threads passed during initialization is greater than zero. If a non-positive value (≤ 0) is provided, the function now logs an error and returns NULL.

Previously, passing num_threads <= 0 would silently proceed, potentially resulting in a thread pool with zero threads—causing jobs to never be executed and thpool_wait() to hang indefinitely.